### PR TITLE
Fix: agent wasn't able to connect to Redis

### DIFF
--- a/copperegg-agent.rb
+++ b/copperegg-agent.rb
@@ -156,7 +156,7 @@ def monitor_redis(redis_servers, group_name, apikey)
       rpass = rhost["password"]
 
       if rpass.nil?
-        redis_uri = "#{rhostname}:#{rport}"
+        redis_uri = "redis://#{rhostname}:#{rport}"
       else
         redis_uri = "redis://redis:#{rpass}@#{rhostname}:#{rport}"
       end


### PR DESCRIPTION
When no password is given for the Redis server, the protocol (redis://) was missing from the constructed URL, which was resulting in failed parsing by the URI class.
